### PR TITLE
Attach source maps to tokens and errors

### DIFF
--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -2,16 +2,18 @@ import Foundation
 
 
 public struct TemplateSyntaxError : Error, Equatable, CustomStringConvertible {
-  public let description:String
+  public let description: String
+  public var sourceMaps: [SourceMap]
 
-  public init(_ description:String) {
+  public init(_ description: String, sourceMaps: [SourceMap]? = nil) {
     self.description = description
+    self.sourceMaps = sourceMaps ?? []
   }
 }
 
 
-public func ==(lhs:TemplateSyntaxError, rhs:TemplateSyntaxError) -> Bool {
-  return lhs.description == rhs.description
+public func ==(lhs: TemplateSyntaxError, rhs: TemplateSyntaxError) -> Bool {
+  return lhs.description == rhs.description && lhs.sourceMaps == rhs.sourceMaps
 }
 
 

--- a/Sources/Parser.swift
+++ b/Sources/Parser.swift
@@ -37,7 +37,7 @@ public class TokenParser {
       let token = nextToken()!
 
       switch token {
-      case .text(let text):
+      case .text(let text, _):
         nodes.append(TextNode(text: text))
       case .variable:
         nodes.append(VariableNode(variable: try compileFilter(token.contents)))

--- a/Sources/SourceMap.swift
+++ b/Sources/SourceMap.swift
@@ -1,0 +1,14 @@
+public struct SourceMap: CustomStringConvertible, Equatable {
+  public let fileName: String?
+  public let start: String.Index
+  public let end: String.Index
+
+  public var description: String {
+    return "SourceMap(\(fileName ?? "") \(start) \(end))"
+  }
+}
+
+
+public func == (lhs: SourceMap, rhs: SourceMap) -> Bool {
+  return lhs.fileName == rhs.fileName && lhs.start == rhs.start && lhs.end == rhs.end
+}

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -18,7 +18,7 @@ open class Template: ExpressibleByStringLiteral {
     self.environment = environment ?? Environment()
     self.name = name
 
-    let lexer = Lexer(templateString: templateString)
+    let lexer = Lexer(fileName: name, templateString: templateString)
     tokens = lexer.tokenize()
   }
 

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -39,41 +39,54 @@ extension String {
 
 public enum Token : Equatable {
   /// A token representing a piece of text.
-  case text(value: String)
+  case text(value: String, sourceMap: SourceMap)
 
   /// A token representing a variable.
-  case variable(value: String)
+  case variable(value: String, sourceMap: SourceMap)
 
   /// A token representing a comment.
-  case comment(value: String)
+  case comment(value: String, sourceMap: SourceMap)
 
   /// A token representing a template block.
-  case block(value: String)
+  case block(value: String, sourceMap: SourceMap)
 
   /// Returns the underlying value as an array seperated by spaces
   public func components() -> [String] {
     switch self {
-    case .block(let value):
+    case .block(let value, _):
       return value.smartSplit()
-    case .variable(let value):
+    case .variable(let value, _):
       return value.smartSplit()
-    case .text(let value):
+    case .text(let value, _):
       return value.smartSplit()
-    case .comment(let value):
+    case .comment(let value, _):
       return value.smartSplit()
     }
   }
 
   public var contents: String {
     switch self {
-    case .block(let value):
+    case .block(let value, _):
       return value
-    case .variable(let value):
+    case .variable(let value, _):
       return value
-    case .text(let value):
+    case .text(let value, _):
       return value
-    case .comment(let value):
+    case .comment(let value, _):
       return value
+    }
+  }
+
+  public var sourceMap: SourceMap {
+    switch self {
+    case .block(_, let sourceMap):
+      return sourceMap
+    case .variable(_, let sourceMap):
+      return sourceMap
+    case .text(_, let sourceMap):
+      return sourceMap
+    case .comment(_, let sourceMap):
+      return sourceMap
     }
   }
 }
@@ -81,14 +94,14 @@ public enum Token : Equatable {
 
 public func == (lhs: Token, rhs: Token) -> Bool {
   switch (lhs, rhs) {
-  case (.text(let lhsValue), .text(let rhsValue)):
-    return lhsValue == rhsValue
-  case (.variable(let lhsValue), .variable(let rhsValue)):
-    return lhsValue == rhsValue
-  case (.block(let lhsValue), .block(let rhsValue)):
-    return lhsValue == rhsValue
-  case (.comment(let lhsValue), .comment(let rhsValue)):
-    return lhsValue == rhsValue
+  case (.text(let lhsValue, let lhsSourceMap), .text(let rhsValue, let rhsSourceMap)):
+    return lhsValue == rhsValue && lhsSourceMap == rhsSourceMap
+  case (.variable(let lhsValue, let lhsSourceMap), .variable(let rhsValue, let rhsSourceMap)):
+    return lhsValue == rhsValue && lhsSourceMap == rhsSourceMap
+  case (.block(let lhsValue, let lhsSourceMap), .block(let rhsValue, let rhsSourceMap)):
+    return lhsValue == rhsValue && lhsSourceMap == rhsSourceMap
+  case (.comment(let lhsValue, let lhsSourceMap), .comment(let rhsValue, let rhsSourceMap)):
+    return lhsValue == rhsValue && lhsSourceMap == rhsSourceMap
   default:
     return false
   }


### PR DESCRIPTION
We should provide source maps so that a template author can easily understand an error raise and which part of the template cause the syntax error.

Stencil should also provide a utility to provide a HTML error page which includes the errernous component of the syntax.

As an example, providing I had the following templates:

#### `article.html`

```html+django
<h5>Comments</h5>

{% for comment in comments %}
  {% include "comment.html" %}
{% endfor %}
```

#### `comment.html`

```html+django
<h6>{{ comment.author }}</h6>

{{ comment }}

{% errblock %}
```

`{% errblock %}` throws an error inside `comment.html` included by `article.html`. The error template should contain two frames, the first frame would contain the context and source map for the `include` tag and the last frame would contain the context during `comment.html` and the source map for `err block`.

There should also be some convenience methods for printing the same information to text (stdout/stderr) perhaps with ANSI colour codes.

### Tasks

- [ ] Compute source maps for tokens.
- [ ] Attach source maps to errors.
- [ ] Ability to wrap TemplateSyntaxError for each frame.
- [ ] HTML rendering.
- [ ] Terminal and text rendering (with / without ANSI codes).