### PR TITLE
Basic numeric expresion handling

### DIFF
--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -115,4 +115,72 @@ func testVariable() {
     }
 #endif
   }
+
+  describe("CompoundVariable") {
+    let context = Context(dictionary: [
+      "name": "Kyle",
+      "a": 3,
+      "x": 20
+    ])
+
+    $0.it("Falls back to default behaviour for strings") {
+      let variable = CompoundVariable("\"name\"")
+      let result = try variable.resolve(context) as? String
+      try expect(result) == "name"
+    }
+
+    $0.it("Falls back to default behaviour for numbers") {
+      let variable = CompoundVariable("5")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == 5
+    }
+
+    $0.it("Falls back to default behaviour for resolvables") {
+      let variable = CompoundVariable("name")
+      let result = try variable.resolve(context) as? String
+      try expect(result) == "Kyle"
+    }
+
+    $0.it("Unresolvables still produce nil") {
+      let variable = CompoundVariable("something")
+      let result = try variable.resolve(context)
+      try expect(result).to.beNil()
+    }
+
+    $0.it("Can add two numbers") {
+      let variable = CompoundVariable("1 + 2")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == 3
+    }
+
+    $0.it("Can substract two numbers") {
+      let variable = CompoundVariable("2 - 4")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == -2
+    }
+
+    $0.it("Can multiply two numbers") {
+      let variable = CompoundVariable("-2 * -4")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == 8
+    }
+
+    $0.it("Can divide two numbers") {
+      let variable = CompoundVariable("4 / 2")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == 2
+    }
+
+    $0.it("Can resolve variables") {
+      let variable = CompoundVariable("a * x")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == 60
+    }
+
+    $0.it("Can process a complex expression") {
+      let variable = CompoundVariable("1 + 2 * 3 - (4 + 6) / 5")
+      let result = try variable.resolve(context) as? Number
+      try expect(result) == 5
+    }
+  }
 }


### PR DESCRIPTION
Stencil has boolean expression handling, but numeric ones. Instead of writing my own ridiculously  complex expression parser, there exists this little gem of a Foundation class called `NSExpression`, so I just used that.

Small problem is that, while it accepts an `object` parameter, this is quite limited, as it won't know how to handle `myArray.count` because `myArray` isn't Key-Value compliant for `count`, and all object leaves must be number values. That's why I rolled my own resolver using Stencil's existing system.

There is a small gotcha with this whole system: if `NSExpression` fails parsing an expression, it throws an Objective-C exception, which Swift can't catch. There are solutions for this, such as http://stackoverflow.com/questions/32758811/catching-nsexception-in-swift, but they would require a small bit of objective-c code.

I've just made a quick implementation to throw the idea out there. It currently works for examples such as `{{ (myArray.count + 5) / 3 - 1 }}`, which is already really cool.