### PR TITLE
Fixed using spaces in filter expressions and variables lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Integer literals now resolve into Int values, not Float
 - Fixed accessing properties of optional properties via reflection
 - No longer render optional values in arrays as `Optional(..)`
+- Adds support for using spaces in filter expression
 
 
 ## 0.10.1

--- a/Sources/ForTag.swift
+++ b/Sources/ForTag.swift
@@ -18,7 +18,7 @@ class ForNode : NodeType {
     let loopVariables = components[1].characters
       .split(separator: ",")
       .map(String.init)
-      .map { $0.trimmingCharacters(in: CharacterSet.whitespaces) }
+      .map { $0.trim(character: " ") }
 
     let variable = components[3]
 

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -10,6 +10,18 @@ extension String {
     var singleQuoteCount = 0
     var doubleQuoteCount = 0
 
+    let specialCharacters = ",|:"
+    func appendWord(_ word: String) {
+      if components.count > 0 &&
+        (specialCharacters.characters.contains(components.last!.characters.last!) ||
+          specialCharacters.contains(word))
+      {
+        components[components.count-1] += word
+      } else {
+        components.append(word)
+      }
+    }
+
     for character in self.characters {
       if character == "'" { singleQuoteCount += 1 }
       else if character == "\"" { doubleQuoteCount += 1 }
@@ -19,7 +31,7 @@ extension String {
         if separate != separator {
           word.append(separate)
         } else if singleQuoteCount % 2 == 0 && doubleQuoteCount % 2 == 0 && !word.isEmpty {
-          components.append(word)
+          appendWord(word)
           word = ""
         }
 
@@ -33,38 +45,11 @@ extension String {
     }
 
     if !word.isEmpty {
-      components.append(word)
+      appendWord(word)
     }
 
-    return smartJoin(components)
+    return components
   }
-}
-
-// joins back components around characters used in variables lists and filters
-private func smartJoin(_ components: [String]) -> [String] {
-  var joinedComponents = components
-  // convert ["a", "|", "b"] and ["a|", "b"] to ["a|b"]
-  // do not allow ["a", "|b"]
-  for char in [",", "|", ":"] {
-    while let index = joinedComponents.index(of: char) {
-      if index > 0 {
-        joinedComponents[index-1] += char
-
-        if joinedComponents.count > index + 1 {
-          joinedComponents[index-1] += joinedComponents[index+1]
-          joinedComponents.remove(at: index+1)
-        }
-      }
-      joinedComponents.remove(at: index)
-    }
-    while let index = joinedComponents.index(where: { $0.hasSuffix(char) }) {
-      if joinedComponents.count > index {
-        joinedComponents[index] += joinedComponents[index+1]
-        joinedComponents.remove(at: index+1)
-      }
-    }
-  }
-  return joinedComponents
 }
 
 

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -36,8 +36,35 @@ extension String {
       components.append(word)
     }
 
-    return components
+    return smartJoin(components)
   }
+}
+
+// joins back components around characters used in variables lists and filters
+private func smartJoin(_ components: [String]) -> [String] {
+  var joinedComponents = components
+  // convert ["a", "|", "b"] and ["a|", "b"] to ["a|b"]
+  // do not allow ["a", "|b"]
+  for char in [",", "|", ":"] {
+    while let index = joinedComponents.index(of: char) {
+      if index > 0 {
+        joinedComponents[index-1] += char
+
+        if joinedComponents.count > index + 1 {
+          joinedComponents[index-1] += joinedComponents[index+1]
+          joinedComponents.remove(at: index+1)
+        }
+      }
+      joinedComponents.remove(at: index)
+    }
+    while let index = joinedComponents.index(where: { $0.hasSuffix(char) }) {
+      if joinedComponents.count > index {
+        joinedComponents[index] += joinedComponents[index+1]
+        joinedComponents.remove(at: index+1)
+      }
+    }
+  }
+  return joinedComponents
 }
 
 

--- a/Sources/Tokenizer.swift
+++ b/Sources/Tokenizer.swift
@@ -12,11 +12,14 @@ extension String {
 
     let specialCharacters = ",|:"
     func appendWord(_ word: String) {
-      if components.count > 0 &&
-        (specialCharacters.characters.contains(components.last!.characters.last!) ||
-          specialCharacters.contains(word))
-      {
-        components[components.count-1] += word
+      if components.count > 0 {
+        if let precedingChar = components.last?.characters.last, specialCharacters.characters.contains(precedingChar) {
+          components[components.count-1] += word
+        } else if specialCharacters.contains(word) {
+          components[components.count-1] += word
+        } else {
+          components.append(word)
+        }
       } else {
         components.append(word)
       }

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -173,11 +173,11 @@ extension Dictionary : Normalizable {
 
 func parseFilterComponents(token: String) -> (String, [Variable]) {
   var components = token.smartSplit(separator: ":")
-  let name = components.removeFirst()
+  let name = components.removeFirst().trim(character: " ")
   let variables = components
     .joined(separator: ":")
     .smartSplit(separator: ",")
-    .map { Variable($0) }
+    .map { Variable($0.trim(character: " ")) }
   return (name, variables)
 }
 

--- a/Tests/StencilTests/FilterSpec.swift
+++ b/Tests/StencilTests/FilterSpec.swift
@@ -78,9 +78,9 @@ func testFilter() {
     }
 
     $0.it("allows whitespace in expression") {
-      let template = Template(templateString: "{{ name | uppercase }}")
-      let result = try template.render(Context(dictionary: ["name": "kyle"]))
-      try expect(result) == "KYLE"
+      let template = Template(templateString: "{{ value | join : \", \" }}")
+      let result = try template.render(Context(dictionary: ["value": ["One", "Two"]]))
+      try expect(result) == "One, Two"
     }
 
     $0.it("throws when you pass arguments to simple filter") {

--- a/Tests/StencilTests/ForNodeSpec.swift
+++ b/Tests/StencilTests/ForNodeSpec.swift
@@ -111,8 +111,8 @@ func testForNode() {
         try expect(try node.render(context)) == "empty"
     }
 
-    $0.it("can render a filter") {
-      let templateString = "{% for article in ars|default:articles %}" +
+    $0.it("can render a filter with spaces") {
+      let templateString = "{% for article in ars | default: a, b , articles %}" +
         "- {{ article.title }} by {{ article.author }}.\n" +
         "{% endfor %}\n"
 
@@ -182,7 +182,7 @@ func testForNode() {
     }
 
     $0.it("can iterate over dictionary") {
-      let templateString = "{% for key,value in dict %}" +
+      let templateString = "{% for key, value in dict %}" +
         "{{ key }}: {{ value }}," +
         "{% endfor %}"
 


### PR DESCRIPTION
When parsing filter expression spaces were not trimmed in filter name and parameters. Also this fixes using spaces in any other nodes where smart split by spaces is used, i.e. in for node. It allows use of `a, b` or `a , b`, but not `a ,b`. The same about `|` and `:` separators. So this also fixes #169 