### PR TITLE
Caching rendered blocks content to reuse them in further calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 - Added support for adding default whitespace trimming behaviour to an environment.  
   [Yonas Kolb](https://github.com/yonaskolb)
   [#287](https://github.com/stencilproject/Stencil/pull/287)
+- Blocks now can be used repeatedly in the template. When block is rendered for the first time its content will be cached and it can be rendered again later using `{{ block.block_name }}`.  
+  [Ilya Puchka](https://github.com/ilyapuchka)
+  [#158](https://github.com/stencilproject/Stencil/issues/158)
+  [#182](https://github.com/stencilproject/Stencil/pull/182)
 
 ### Deprecations
 

--- a/Sources/Stencil/Context.swift
+++ b/Sources/Stencil/Context.swift
@@ -85,4 +85,19 @@ public class Context {
 
     return accumulator
   }
+
+  /// Cache result of block by its name in the context top-level, so that it can be later rendered
+  /// via `{{ block.name }}`
+  ///
+  /// - Parameters:
+  ///   - name: The name of the stored block
+  ///   - content: The block's rendered content
+  public func cacheBlock(_ name: String, content: String) {
+    if var block = dictionaries.first?["block"] as? [String: String] {
+      block[name] = content
+      dictionaries[0]["block"] = block
+    } else {
+      dictionaries.insert(["block": [name: content]], at: 0)
+    }
+  }
 }

--- a/Sources/Stencil/Inheritance.swift
+++ b/Sources/Stencil/Inheritance.swift
@@ -151,6 +151,8 @@ class BlockNode: NodeType {
       }
     }
 
-    return try renderNodes(nodes, context)
+    let result = try renderNodes(nodes, context)
+    context.cacheBlock(name, content: result)
+    return result
   }
 }

--- a/Tests/StencilTests/InheritanceSpec.swift
+++ b/Tests/StencilTests/InheritanceSpec.swift
@@ -52,4 +52,22 @@ final class InheritanceTests: XCTestCase {
       """
     }
   }
+
+  func testInheritanceCache() {
+    it("can call block twice") {
+      let template: Template = "{% block repeat %}Block{% endblock %}{{ block.repeat }}"
+      try expect(try template.render()) == "BlockBlock"
+    }
+
+    it("renders child content when calling block twice in base template") {
+      let template = try self.environment.loadTemplate(name: "child-repeat.html")
+      try expect(try template.render()) == """
+      Super_Header Child_Header
+      Child_Body
+      Repeat
+      Super_Header Child_Header
+      Child_Body
+      """
+    }
+  }
 }

--- a/Tests/StencilTests/fixtures/base-repeat.html
+++ b/Tests/StencilTests/fixtures/base-repeat.html
@@ -1,0 +1,5 @@
+{% block header %}Header{% endblock %}
+{% block body %}Body{% endblock %}
+Repeat
+{{ block.header }}
+{{ block.body }}

--- a/Tests/StencilTests/fixtures/child-repeat.html
+++ b/Tests/StencilTests/fixtures/child-repeat.html
@@ -1,0 +1,3 @@
+{% extends "base-repeat.html" %}
+{% block header %}Super_{{ block.super }} Child_Header{% endblock %}
+{% block body %}Child_Body{% endblock %}

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -141,7 +141,7 @@ Let's take a look at an example. Here is our base template (``base.html``):
     </html>
 
 This example declares three blocks, ``title``, ``sidebar`` and ``content``. We
-can use the ``{% extends %}`` template tag to inherit from out base template
+can use the ``{% extends %}`` template tag to inherit from our base template
 and then use ``{% block %}`` to override any blocks from our base template.
 
 A child template might look like the following:
@@ -195,3 +195,5 @@ inheritance is the following three-level approach:
   extend ``base.html`` and include section-specific styles/design.
 * Create individual templates for each type of page, such as a news article or
   blog entry. These templates extend the appropriate section template.
+
+You can render block's content more than once by using ``{{ block.name }}`` **after** a block is defined.


### PR DESCRIPTION
Resolves #158 
This PR implements caching of rendered blocks context in the top context so that it can be later rendered again using variable expression.

Example:

```
<title>{% block title %}Hello World!{% endblock %}</title>
<h1>{{ block.title }}</h1>
```

Result:

```
<title>Hello World!</title>
<h1>Hello World!</h1>
```

In case of inheritance cached content is updated each time child block is rendered, so when block repeats in the base template its content will be the same as content of the first block invocation, containing all its children contents.

Example:

```
base.html

<title>{% block title %}Hello World!{% endblock %}</title>
<h1>{{ block.title }}</h1>
```

```
child.html

{% extends base.html %}
<title>{% block title %}{{ block.super}} Foo Bar {% endblock %}</title>
```

Result (when rendering child.html):

```
<title>Hello World! Foo Bar</title>
<h1>Hello World! Foo Bar</h1>
```
