### PR TITLE
Optimise Scanner performance

### DIFF
--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -7,7 +7,7 @@ struct Lexer {
 
   func createToken(string: String) -> Token {
     func strip() -> String {
-      guard string.characters.count > 4 else { return "" }
+      guard string.count > 4 else { return "" }
       let start = string.index(string.startIndex, offsetBy: 2)
       let end = string.index(string.endIndex, offsetBy: -2)
       let trimmed = String(string[start..<end])
@@ -42,7 +42,7 @@ struct Lexer {
     ]
 
     while !scanner.isEmpty {
-      if let text = scanner.scan(until: ["{{", "{%", "{#"]) {
+      if let text = scanner.scanForTokenStart() {
         if !text.1.isEmpty {
           tokens.append(createToken(string: text.1))
         }
@@ -73,31 +73,61 @@ class Scanner {
   }
 
   func scan(until: String, returnUntil: Bool = false) -> String {
-    if until.isEmpty {
+    guard let first = until.unicodeScalars.first else {
       return ""
     }
 
-    var index = content.startIndex
-    while index != content.endIndex {
-      let substring = content.substring(from: index)
-
-      if substring.hasPrefix(until) {
-        let result = content.substring(to: index)
-        content = substring
-
-        if returnUntil {
-          content = content.substring(from: until.endIndex)
-          return result + until
+    var index = 0;
+    for char in content.unicodeScalars {
+      if char == first {
+        //Check the rest
+        if String(content[content.startIndex.advanced(by: index)..<content.startIndex.advanced(by: index + until.count)]) == until {
+          let result = String(content[..<content.startIndex.advanced(by: index)])
+          content = String(content[content.startIndex.advanced(by: index)...])
+          if returnUntil {
+            content = String(content[content.startIndex.advanced(by: until.count)...])
+            return result + until
+          }
+          return result
         }
-
-        return result
       }
-
-      index = content.index(after: index)
+      index += 1
     }
 
     content = ""
     return ""
+  }
+  func scanForTokenStart() -> (String, String)? {
+    var foundBrace = false
+    var index = 0;
+    for char in content.unicodeScalars {
+      if foundBrace {
+        let string:String
+        switch char {
+          case "{":
+            string = "{{"
+          case "%":
+            string = "{%"
+          case "#":
+            string = "{#"
+          default:
+            foundBrace = false
+            index += 2
+            continue;
+        }
+        let result = String(content[..<content.startIndex.advanced(by: index)])
+        content = String(content[content.startIndex.advanced(by: index)...])
+        return (string, result)
+      } else {
+        if char == "{" {
+          //Check next char
+          foundBrace = true
+        } else {
+          index += 1
+        }
+      }
+    }    
+    return nil;
   }
 
   func scan(until: [String]) -> (String, String)? {

--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -40,9 +40,11 @@ struct Lexer {
       "{%": "%}",
       "{#": "#}",
     ]
+    //let startTokens = ["{{", "{%", "{#"]
+    let tokenChars:[Unicode.Scalar] = ["{", "%", "#"]
 
     while !scanner.isEmpty {
-      if let text = scanner.scanForTokenStart() {
+      if let text = scanner.scanForTokenStart(tokenChars) {
         if !text.1.isEmpty {
           tokens.append(createToken(string: text.1))
         }
@@ -98,23 +100,44 @@ class Scanner {
     content = ""
     return ""
   }
-  func scanForTokenStart() -> (String, String)? {
+  func scan(until: [String]) -> (String, String)? {
+    if until.isEmpty {
+      return nil
+    }
+
+    var index = 0;
+    for char in content.unicodeScalars {
+      for string in until {
+        if string.unicodeScalars.first == char {
+          let startIndex = content.startIndex.advanced(by: index)
+          let endIndex = content.startIndex.advanced(by: index + string.count)
+          if endIndex > content.endIndex {
+            continue;
+          }
+          if String(content[startIndex..<endIndex]) == string {
+            let result = String(content[..<startIndex])
+            content = String(content[startIndex...])
+            return (string, result)
+          }
+        }
+      }
+      index += 1
+    }
+
+    return nil;
+  }
+  func scanForTokenStart(_ tokenChars:[Unicode.Scalar]) -> (String, String)? {
     var foundBrace = false
     var index = 0;
     for char in content.unicodeScalars {
       if foundBrace {
         let string:String
-        switch char {
-          case "{":
-            string = "{{"
-          case "%":
-            string = "{%"
-          case "#":
-            string = "{#"
-          default:
-            foundBrace = false
-            index += 2
-            continue;
+        if tokenChars.contains(char) {
+          string = "{\(char)"
+        } else {
+          foundBrace = false
+          index += 2
+          continue;
         }
         let startIndex = content.startIndex.advanced(by: index)
         let result = String(content[..<startIndex])
@@ -130,28 +153,6 @@ class Scanner {
       }
     }    
     return nil;
-  }
-
-  func scan(until: [String]) -> (String, String)? {
-    if until.isEmpty {
-      return nil
-    }
-
-    var index = content.startIndex
-    while index != content.endIndex {
-      let substring = content.substring(from: index)
-      for string in until {
-        if substring.hasPrefix(string) {
-          let result = content.substring(to: index)
-          content = substring
-          return (string, result)
-        }
-      }
-
-      index = content.index(after: index)
-    }
-
-    return nil
   }
 }
 

--- a/Sources/Lexer.swift
+++ b/Sources/Lexer.swift
@@ -81,9 +81,10 @@ class Scanner {
     for char in content.unicodeScalars {
       if char == first {
         //Check the rest
-        if String(content[content.startIndex.advanced(by: index)..<content.startIndex.advanced(by: index + until.count)]) == until {
-          let result = String(content[..<content.startIndex.advanced(by: index)])
-          content = String(content[content.startIndex.advanced(by: index)...])
+        let startIndex = content.startIndex.advanced(by: index)
+        if String(content[startIndex..<content.startIndex.advanced(by: index + until.count)]) == until {
+          let result = String(content[..<startIndex])
+          content = String(content[startIndex...])
           if returnUntil {
             content = String(content[content.startIndex.advanced(by: until.count)...])
             return result + until
@@ -115,8 +116,9 @@ class Scanner {
             index += 2
             continue;
         }
-        let result = String(content[..<content.startIndex.advanced(by: index)])
-        content = String(content[content.startIndex.advanced(by: index)...])
+        let startIndex = content.startIndex.advanced(by: index)
+        let result = String(content[..<startIndex])
+        content = String(content[startIndex...])
         return (string, result)
       } else {
         if char == "{" {


### PR DESCRIPTION
Our project has a few larger templates. After going from Swift 3.1 to 4.1, we noticed a huge performance hit and narrowed it down to here. Under one files test case we are seeing improvements from over 8 seconds down to ~0.15 seconds on our Ubuntu server, and ~0.6 seconds down to ~0.15 on macOS. We are seeing about this performance ratio across all files.

This pull also includes the original scan(until: [String]) function rewritten, but this is about twice as slow as the scanForTokenStart approach.

Open to modifying if required.