### PR TITLE
Context param for Include block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Enhancements
 
-- added an optional second parameter to the `include` tag for passing a sub context to the included file
+- Added an optional second parameter to the `include` tag for passing a sub context to the included file.  
+  [Yonas Kolb](https://github.com/yonaskolb)
+  [#394](https://github.com/stencilproject/Stencil/pull/214)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+### Enhancements
+
+- added an optional second parameter to the `include` tag for passing a sub context to the included file
+
 ### Bug Fixes
 
 - Fixed using quote as a filter parameter

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -27,7 +27,7 @@ class IncludeNode : NodeType {
 
     let template = try context.environment.loadTemplate(name: templateName)
 
-    let subContext = includeContext.flatMap{ context[$0] as? [String: Any] }
+    let subContext = includeContext.flatMap { context[$0] as? [String: Any] }
     return try context.push(dictionary: subContext) {
       return try template.render(context)
     }

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -8,11 +8,11 @@ class IncludeNode : NodeType {
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
     let bits = token.components()
 
-    guard bits.count == 2 || (bits.count == 4 && bits[2] == "using") else {
-      throw TemplateSyntaxError("'include' tag requires one argument, the template file to be included. Another optional argument can be used to specify the context that will be passed to the included file, using the format \"using myContext\"")
+    guard bits.count == 2 || bits.count == 3 else {
+      throw TemplateSyntaxError("'include' tag requires one argument, the template file to be included. A second optional argument can be used to specify the context that will be passed to the included file")
     }
 
-    return IncludeNode(templateName: Variable(bits[1]), includeContext: bits.count == 4 ? bits[3] : nil)
+    return IncludeNode(templateName: Variable(bits[1]), includeContext: bits.count == 3 ? bits[2] : nil)
   }
 
   init(templateName: Variable, includeContext: String? = nil) {

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -14,7 +14,7 @@ func testInclude() {
         let tokens: [Token] = [ .block(value: "include") ]
         let parser = TokenParser(tokens: tokens, environment: Environment())
 
-        let error = TemplateSyntaxError("'include' tag takes one argument, the template file to be included")
+        let error = TemplateSyntaxError("'include' tag requires one argument, the template file to be included. Another optional argument can be used to specify the context that will be passed to the included file, using the format \"using myContext\"")
         try expect(try parser.parse()).toThrow(error)
       }
 
@@ -54,6 +54,13 @@ func testInclude() {
         let node = IncludeNode(templateName: Variable("\"test.html\""))
         let context = Context(dictionary: ["target": "World"], environment: environment)
         let value = try node.render(context)
+        try expect(value) == "Hello World!"
+      }
+
+      $0.it("successfully passes context") {
+        let template = Template(templateString: "{% include \"test.html\" using child %}")
+        let context = Context(dictionary: ["child": ["target": "World"]], environment: environment)
+        let value = try template.render(context)
         try expect(value) == "Hello World!"
       }
     }

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -14,7 +14,7 @@ func testInclude() {
         let tokens: [Token] = [ .block(value: "include") ]
         let parser = TokenParser(tokens: tokens, environment: Environment())
 
-        let error = TemplateSyntaxError("'include' tag requires one argument, the template file to be included. Another optional argument can be used to specify the context that will be passed to the included file, using the format \"using myContext\"")
+        let error = TemplateSyntaxError("'include' tag requires one argument, the template file to be included. A second optional argument can be used to specify the context that will be passed to the included file")
         try expect(try parser.parse()).toThrow(error)
       }
 
@@ -58,7 +58,7 @@ func testInclude() {
       }
 
       $0.it("successfully passes context") {
-        let template = Template(templateString: "{% include \"test.html\" using child %}")
+        let template = Template(templateString: "{% include \"test.html\" child %}")
         let context = Context(dictionary: ["child": ["target": "World"]], environment: environment)
         let value = try template.render(context)
         try expect(value) == "Hello World!"

--- a/docs/builtins.rst
+++ b/docs/builtins.rst
@@ -260,6 +260,12 @@ You can include another template using the `include` tag.
 
     {% include "comment.html" %}
 
+By default the included file gets passed the current context. You can pass a sub context by using an optional 2nd parameter as a lookup in the current context.
+
+.. code-block:: html+django
+
+    {% include "comment.html" comment %}
+
 The `include` tag requires you to provide a loader which will be used to lookup
 the template.
 


### PR DESCRIPTION
This is a redo of #95 which only includes the context param which gets passed to the file.
I've also removed the `using` from the param

```
{% include "file.stencil" childContext %}
```