### PR TITLE
Add Package.swift for Swift 4.2

### DIFF
--- a/Package@swift-4.2.swift
+++ b/Package@swift-4.2.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+  name: "Stencil",
+  products: [
+    .library(name: "Stencil", targets: ["Stencil"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/kylef/PathKit.git", from: "0.9.0"),
+    .package(url: "https://github.com/kylef/Spectre.git", from: "0.8.0"),
+  ],
+  targets: [
+    .target(name: "Stencil", dependencies: [
+      "PathKit",
+    ], path: "Sources"),
+    .testTarget(name: "StencilTests", dependencies: [
+      "Stencil",
+      "Spectre",
+    ])
+  ],
+  swiftLanguageVersions: [.v4, .v4_2]
+)


### PR DESCRIPTION
This allows Stencil to be compiled with Swift 4.2

We should wait for new releases including https://github.com/kylef/PathKit/pull/56 and https://github.com/kylef/Spectre/pull/37

Also once Swift 4.2 is officially released we can add a CI job for it.