### PR TITLE
Dynamic member lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ _None_
 - Made the `Template.render(_:)` method (that accepts a `Context`) public.  
   [David Jennes](https://github.com/djbe)
   [#322](https://github.com/stencilproject/Stencil/pull/322)
+- Enable dynamic member lookup using a new `DynamicMemberLookup` protocol. Conform your own types to this protocol to support dynamic member from with contexts.  
+  [Ilya Puchka](https://github.com/ilyapuchka)
+  [#219](https://github.com/stencilproject/Stencil/issues/219)
+  [#246](https://github.com/stencilproject/Stencil/pull/246)
 
 ### Deprecations
 

--- a/Sources/DynamicMemberLookup.swift
+++ b/Sources/DynamicMemberLookup.swift
@@ -1,0 +1,15 @@
+/// Marker protocol so we can know which types support `@dynamicMemberLookup`. Add this to your own types that support
+/// lookup by String.
+public protocol DynamicMemberLookup {
+  /// Get a value for a given `String` key
+  subscript(dynamicMember member: String) -> Any? { get }
+}
+
+public extension DynamicMemberLookup where Self: RawRepresentable {
+  subscript(dynamicMember member: String) -> Any? {
+    switch member {
+    case "rawValue": return rawValue
+    default: return nil
+    }
+  }
+}

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -110,6 +110,8 @@ public struct Variable: Equatable, Resolvable {
           return object.value(forKey: bit)
         }
       #endif
+    } else if let value = context as? DynamicMemberLookup {
+      return value[dynamicMember: bit]
     } else if let value = context {
       return Mirror(reflecting: value).getValue(for: bit)
     }

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -30,6 +30,17 @@ private class Blog: WebSite {
   let featuring: Article? = Article(author: Person(name: "Jhon"))
 }
 
+@dynamicMemberLookup
+private struct DynamicStruct: DynamicMemberLookup {
+  subscript(dynamicMember member: String) -> Any? {
+    member == "test" ? "this is a dynamic response" : nil
+  }
+}
+
+private enum DynamicEnum: String, DynamicMemberLookup {
+  case someValue = "this is raw value"
+}
+
 final class VariableTests: XCTestCase {
   let context: Context = {
     let ext = Extension()
@@ -49,7 +60,11 @@ final class VariableTests: XCTestCase {
       ],
       "article": Article(author: Person(name: "Kyle")),
       "blog": Blog(),
-      "tuple": (one: 1, two: 2)
+      "tuple": (one: 1, two: 2),
+      "dynamic": [
+        "enum": DynamicEnum.someValue,
+        "struct": DynamicStruct()
+      ]
     ], environment: environment)
 #if os(OSX)
     context["object"] = Object()
@@ -155,6 +170,20 @@ final class VariableTests: XCTestCase {
       let variable = Variable("contacts.last")
       let result = try variable.resolve(self.context) as? String
       try expect(result) == "Carlton"
+    }
+  }
+
+  func testDynamicMemberLookup() {
+    it("can resolve dynamic member lookup") {
+      let variable = Variable("dynamic.struct.test")
+      let result = try variable.resolve(self.context) as? String
+      try expect(result) == "this is a dynamic response"
+    }
+
+    it("can resolve dynamic enum rawValue") {
+      let variable = Variable("dynamic.enum.rawValue")
+      let result = try variable.resolve(self.context) as? String
+      try expect(result) == "this is raw value"
     }
   }
 

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -22,6 +22,7 @@ following lookup:
 - Dictionary lookup
 - Array and string lookup (first, last, count, by index)
 - Key value coding lookup
+- @dynamicMemberLookup when conforming to our `DynamicMemberLookup` marker protocol
 - Type introspection (via ``Mirror``)
 
 For example, if `people` was an array:


### PR DESCRIPTION
This is similar to `@dynamicMemberLookup` in Swift. Would be ideal if there was a way to check if the type supports this in runtime but it's not possible, so had to introduce a custom protocol for that.
Alternatively, we could have a protocol `StencilContextConvertible` that will require to expose dictionary to be used in template context, but that will require to add all properties in such dictionary, even those accessible through reflection, instead of only those which are not accessible this way.
Unfortunately, this does not work out of the box (by just adding `DynamicMemberLookup` conformance) with `@dynamicMemberLookup` unless type defines subscript with `Any?` return type.
Resolves #219