### PR TITLE
Decouple from PathKit

### DIFF
--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -1,4 +1,3 @@
-import PathKit
 
 
 class IncludeNode : NodeType {

--- a/Sources/Loader.swift
+++ b/Sources/Loader.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PathKit
 
 
 public protocol Loader {
@@ -17,56 +16,6 @@ extension Loader {
         continue
       } catch {
         throw error
-      }
-    }
-
-    throw TemplateDoesNotExist(templateNames: names, loader: self)
-  }
-}
-
-
-// A class for loading a template from disk
-public class FileSystemLoader: Loader, CustomStringConvertible {
-  public let paths: [Path]
-
-  public init(paths: [Path]) {
-    self.paths = paths
-  }
-
-  public init(bundle: [Bundle]) {
-    self.paths = bundle.map {
-      return Path($0.bundlePath)
-    }
-  }
-
-  public var description: String {
-    return "FileSystemLoader(\(paths))"
-  }
-
-  public func loadTemplate(name: String, environment: Environment) throws -> Template {
-    for path in paths {
-      let templatePath = try path.safeJoin(path: Path(name))
-
-      if !templatePath.exists {
-        continue
-      }
-
-      let content: String = try templatePath.read()
-      return environment.templateClass.init(templateString: content, environment: environment, name: name)
-    }
-
-    throw TemplateDoesNotExist(templateNames: [name], loader: self)
-  }
-
-  public func loadTemplate(names: [String], environment: Environment) throws -> Template {
-    for path in paths {
-      for templateName in names {
-        let templatePath = try path.safeJoin(path: Path(templateName))
-
-        if templatePath.exists {
-          let content: String = try templatePath.read()
-          return environment.templateClass.init(templateString: content, environment: environment, name: templateName)
-        }
       }
     }
 
@@ -98,33 +47,5 @@ public class DictionaryLoader: Loader {
     }
 
     throw TemplateDoesNotExist(templateNames: names, loader: self)
-  }
-}
-
-
-extension Path {
-  func safeJoin(path: Path) throws -> Path {
-    let newPath = self + path
-
-    if !newPath.absolute().description.hasPrefix(absolute().description) {
-      throw SuspiciousFileOperation(basePath: self, path: newPath)
-    }
-
-    return newPath
-  }
-}
-
-
-class SuspiciousFileOperation: Error {
-  let basePath: Path
-  let path: Path
-
-  init(basePath: Path, path: Path) {
-    self.basePath = basePath
-    self.path = path
-  }
-
-  var description: String {
-    return "Path `\(path)` is located outside of base path `\(basePath)`"
   }
 }

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -1,5 +1,4 @@
 import Foundation
-import PathKit
 
 #if os(Linux)
 let NSFileNoSuchFileError = 4
@@ -22,29 +21,6 @@ open class Template: ExpressibleByStringLiteral {
 
     let lexer = Lexer(templateName: name, templateString: templateString)
     tokens = lexer.tokenize()
-  }
-
-  /// Create a template with the given name inside the given bundle
-  @available(*, deprecated, message: "Use Environment/FileSystemLoader instead")
-  public convenience init(named:String, inBundle bundle:Bundle? = nil) throws {
-    let useBundle = bundle ??  Bundle.main
-    guard let url = useBundle.url(forResource: named, withExtension: nil) else {
-      throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
-    }
-
-    try self.init(URL:url)
-  }
-
-  /// Create a template with a file found at the given URL
-  @available(*, deprecated, message: "Use Environment/FileSystemLoader instead")
-  public convenience init(URL:Foundation.URL) throws {
-    try self.init(path: Path(URL.path))
-  }
-
-  /// Create a template with a file found at the given path
-  @available(*, deprecated, message: "Use Environment/FileSystemLoader instead")
-  public convenience init(path: Path, environment: Environment? = nil, name: String? = nil) throws {
-    self.init(templateString: try path.read(), environment: environment, name: name)
   }
 
   // MARK: ExpressibleByStringLiteral


### PR DESCRIPTION
Remove FileSystemLoader in case not needed for projects and break PathKit coupling. Further discussion in #120.