### PR TITLE
always evaluate block.super even if it is not used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fixed using `{{ block.super }}` inside nodes other than `block`.  
+  [Ilya Puchka](https://github.com/ilyapuchka)
+  [#266](https://github.com/stencilproject/Stencil/issues/266)
+  [#267](https://github.com/stencilproject/Stencil/pull/267)
 
 ### Internal Changes
 

--- a/Tests/StencilTests/EnvironmentSpec.swift
+++ b/Tests/StencilTests/EnvironmentSpec.swift
@@ -320,7 +320,7 @@ final class EnvironmentBaseAndChildTemplateTests: XCTestCase {
     baseTemplate = try environment.loadTemplate(name: "invalid-base.html")
 
     try expectError(reason: "filter error",
-                    childToken: "block.super",
+                    childToken: "extends \"invalid-base.html\"",
                     baseToken: "target|unknown")
   }
 

--- a/Tests/StencilTests/InheritanceSpec.swift
+++ b/Tests/StencilTests/InheritanceSpec.swift
@@ -32,5 +32,24 @@ final class InheritanceTests: XCTestCase {
         Child_Body
         """
     }
+
+    it("can render block.super in if tag") {
+      let template = try self.environment.loadTemplate(name: "if-block-child.html")
+
+      try expect(try template.render(["sort": "new"])) == """
+      Title - Nieuwste spellen
+
+      """
+
+      try expect(try template.render(["sort": "upcoming"])) == """
+      Title - Binnenkort op de agenda
+
+      """
+
+      try expect(try template.render(["sort": "near-me"])) == """
+      Title - In mijn buurt
+
+      """
+    }
   }
 }

--- a/Tests/StencilTests/fixtures/if-block-child.html
+++ b/Tests/StencilTests/fixtures/if-block-child.html
@@ -1,0 +1,2 @@
+{% extends "if-block.html" %}
+{% block title %}{% if sort == "new" %}{{ block.super }} - Nieuwste spellen{% elif sort == "upcoming" %}{{ block.super }} - Binnenkort op de agenda{% elif sort == "near-me" %}{{ block.super }} - In mijn buurt{% endif %}{% endblock %}

--- a/Tests/StencilTests/fixtures/if-block.html
+++ b/Tests/StencilTests/fixtures/if-block.html
@@ -1,0 +1,1 @@
+{% block title %}Title{% endblock %}


### PR DESCRIPTION
Resolves #266 

The issue is caused by the fact that we were trying to avoid rendering `block.super` when it is not used in a child template by searching for such variable inside `block` node. The problem is that if inside this node there are other nodes, i.e. `{% if %}` then we are not searching inside them. We could potentially search for it recursively, but this can lead to unneeded code and runtime complexity. Instead we can always render it when rendering `extend` node.

This will come at a cost of possibly unneeded rendering of the block (which still may be cheeper than going through nodes tree searching for it) and any errors in the base block being reported for `{% extends %}` node (see changed test case) instead of `{{ block.super }}`. 

Searching for `block.super` would not work reliably for error reporting any way because we are searching only for first occasion of `block.super` node, where at runtime actual rendering may be happening in another place (i.e. in a different branch of `if` node).

Alternatively we could render the content of `block.super` lazily by storing closure instead of rendered value in the context, but quick change like that resulted in infinite recursion and probably requires more changes to make it work.