### PR TITLE
Fixed nil mirrored values detection

### DIFF
--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -249,7 +249,7 @@ extension Mirror {
       // go through inheritance chain to reach superclass properties
       return superclassMirror?.getValue(for: key)
     } else if let result = result {
-      guard String(describing: result) != "nil" else {
+      guard String(describing: result) != "nil", String(describing: result) != "none" else {
         // mirror returns non-nil value even for nil-containing properties
         // so we have to check if its value is actually nil or not
         return nil


### PR DESCRIPTION
Hello,

I ran into this strange bug while I was working on [Weaver](https://github.com/scribd/Weaver).

One of the attributes set to `nil` is interpreted as `none` by Stencil. After debugging into Stencil, I found out that the problem came from the description of the attribute value which is in my particular case `none` rather than `nil`. When printing `result`, the debugger shows `nil` though.

I'm not sure what is the rule behind that, and I actually haven't been able to write a test that reproduces the issue, but I made a [branch](https://github.com/scribd/Weaver/tree/stencil-bug-report) on Weaver's repo which reproduces the bug every-time. To test, just checkout that branch and open `Weaver.xcodeproj`, then run the target `WeaverCommand` with the debugger on, and you should get the same result as the following screenshot. 

<img width="1042" alt="screen shot 2019-02-10 at 5 20 41 pm" src="https://user-images.githubusercontent.com/3514976/52542789-3a4ce280-2d58-11e9-8da4-7f30607e0db2.png">

I think that, even though I couldn't reproduce the bug in a unit test, I have a proof that `String(describing: result)` can take the value "none" and thus that it should be checked. But of course, if anyone has an explanation for this behavior, I'm open to better suggestions.