### PR TITLE
Allow context to be initialised with Any

### DIFF
--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -14,6 +14,10 @@ public class Context {
     self.environment = environment ?? Environment()
   }
 
+  convenience init(object: Any? = nil, environment: Environment? = nil) {
+    self.init(dictionary: Context.dictionaryFromAny(object: object ?? [:]), environment: environment)
+  }
+    
   public subscript(key: String) -> Any? {
     /// Retrieves a variable's value, starting at the current context and going upwards
     get {
@@ -45,13 +49,29 @@ public class Context {
     return dictionaries.popLast()
   }
 
+  /// return a dictionary describing an object
+  static fileprivate func dictionaryFromAny(object: Any) -> [String: Any] {
+    if let dictionary = object as? [String: Any] {
+      return dictionary
+    } else {
+      let dictionary = Mirror(reflecting: object).asDictionary()
+      return dictionary
+    }
+  }
+    
   /// Push a new level onto the context for the duration of the execution of the given closure
   public func push<Result>(dictionary: [String: Any] = [:], closure: (() throws -> Result)) rethrows -> Result {
     push(dictionary)
     defer { _ = pop() }
     return try closure()
   }
-
+    
+  /// Push a new level onto the context for the duration of the execution of the given closure
+  public func push<Result>(object: Any, closure: (() throws -> Result)) rethrows -> Result {
+    let dictionary = Context.dictionaryFromAny(object: object)
+    return try push(dictionary: dictionary, closure: closure)
+  }
+    
   public func flatten() -> [String: Any] {
     var accumulator: [String: Any] = [:]
 

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -54,8 +54,7 @@ public class Context {
     if let dictionary = object as? [String: Any] {
       return dictionary
     } else {
-      let dictionary = Mirror(reflecting: object).asDictionary()
-      return dictionary
+      return Mirror(reflecting: object).asDictionary()
     }
   }
     

--- a/Sources/Context.swift
+++ b/Sources/Context.swift
@@ -14,7 +14,7 @@ public class Context {
     self.environment = environment ?? Environment()
   }
 
-  convenience init(object: Any? = nil, environment: Environment? = nil) {
+  convenience public init(object: Any? = nil, environment: Environment? = nil) {
     self.init(dictionary: Context.dictionaryFromAny(object: object ?? [:]), environment: environment)
   }
     

--- a/Sources/Environment.swift
+++ b/Sources/Environment.swift
@@ -29,20 +29,20 @@ public struct Environment {
     }
   }
 
-  public func renderTemplate(name: String, context: [String: Any] = [:]) throws -> String {
+  public func renderTemplate(name: String, context: Any? = nil) throws -> String {
     let template = try loadTemplate(name: name)
     return try render(template: template, context: context)
   }
 
-  public func renderTemplate(string: String, context: [String: Any] = [:]) throws -> String {
+  public func renderTemplate(string: String, context: Any? = nil) throws -> String {
     let template = templateClass.init(templateString: string, environment: self)
     return try render(template: template, context: context)
   }
 
-  func render(template: Template, context: [String: Any]) throws -> String {
+  func render(template: Template, context: Any?) throws -> String {
     // update template environment as it can be created from string literal with default environment
     template.environment = self
-    return try template.render(context)
+    return try template.render(object: context)
   }
 
 }

--- a/Sources/Include.swift
+++ b/Sources/Include.swift
@@ -33,8 +33,8 @@ class IncludeNode: NodeType {
     let template = try context.environment.loadTemplate(name: templateName)
 
     do {
-      let subContext = includeContext.flatMap { context[$0] as? [String: Any] } ?? [:]
-      return try context.push(dictionary: subContext) {
+      let subContext = includeContext.flatMap { context[$0] } ?? [:]
+      return try context.push(object: subContext) {
         try template.render(context)
       }
     } catch {

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -73,8 +73,12 @@ open class Template: ExpressibleByStringLiteral {
   }
 
   // swiftlint:disable discouraged_optional_collection
-  /// Render the given template
   open func render(_ dictionary: [String: Any]? = nil) throws -> String {
     return try render(Context(dictionary: dictionary ?? [:], environment: environment))
+  }
+
+  /// Render the given template
+  open func render(object: Any?) throws -> String {
+    return try render(Context(object: object, environment: environment))
   }
 }

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -267,7 +267,11 @@ extension Mirror {
     var dictionary : [String: Any] = superclassMirror?.asDictionary() ?? [:]
     for child in children {
       if let name = child.label {
-        dictionary[name] = child.value
+        if let result = (child.value as? AnyOptional)?.wrapped {
+            dictionary[name] = result
+        } else {
+            dictionary[name] = child.value
+        }
       }
     }
     return dictionary

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -262,6 +262,16 @@ extension Mirror {
     }
     return result
   }
+    
+  func asDictionary() -> [String: Any] {
+    var dictionary : [String: Any] = superclassMirror?.asDictionary() ?? [:]
+    for child in children {
+      if let name = child.label {
+        dictionary[name] = child.value
+      }
+    }
+    return dictionary
+  }
 }
 
 protocol AnyOptional {

--- a/Tests/StencilTests/ContextSpec.swift
+++ b/Tests/StencilTests/ContextSpec.swift
@@ -88,4 +88,32 @@ final class ContextTests: XCTestCase {
       }
     }
   }
+    
+  func testContextAnyInitialization() {
+    class SuperTest {
+      init() {}
+      let int : Int = 23
+    }
+    class Test : SuperTest {
+      override init() {
+        super.init()
+      }
+      let string : String = "test string"
+      let optional : String? = "test optional"
+      let nilOptional : String? = nil
+    }
+    describe("Any Initialization") {
+      var context = Context()
+      $0.before {
+        context = Context(object: Test())
+      }
+    
+      $0.it("Test dictionary values") {
+        try expect(context["int"] as? Int) == 23
+        try expect(context["string"] as? String) == "test string"
+        try expect(context["optional"] as? String)  == "test optional"
+        try expect(context["nilOptional"] == nil) == true
+      }
+    }
+  }
 }

--- a/Tests/StencilTests/EnvironmentSpec.swift
+++ b/Tests/StencilTests/EnvironmentSpec.swift
@@ -438,7 +438,7 @@ private class ExampleLoader: Loader {
 
 private class CustomTemplate: Template {
   // swiftlint:disable discouraged_optional_collection
-  override func render(_ dictionary: [String: Any]? = nil) throws -> String {
+  override func render(object: Any? = nil) throws -> String {
     return "here"
   }
 }

--- a/Tests/StencilTests/StencilSpec.swift
+++ b/Tests/StencilTests/StencilSpec.swift
@@ -44,7 +44,7 @@ final class StencilTests: XCTestCase {
       ]
 
       let template = Template(templateString: templateString)
-      let result = try template.render(context)
+      let result = try template.render(object: context)
 
       try expect(result) == """
         There are 2 articles.

--- a/Tests/StencilTests/TemplateSpec.swift
+++ b/Tests/StencilTests/TemplateSpec.swift
@@ -6,7 +6,7 @@ final class TemplateTests: XCTestCase {
   func testTemplate() {
     it("can render a template from a string") {
       let template = Template(templateString: "Hello World")
-      let result = try template.render(object:[ "name": "Kyle" ])
+      let result = try template.render(object: ["name": "Kyle"])
       try expect(result) == "Hello World"
     }
 

--- a/Tests/StencilTests/TemplateSpec.swift
+++ b/Tests/StencilTests/TemplateSpec.swift
@@ -12,7 +12,7 @@ final class TemplateTests: XCTestCase {
 
     it("can render a template from a string literal") {
         let template: Template = "Hello World"
-        let result = try template.render(object:[ "name": "Kyle" ])
+        let result = try template.render(object: ["name": "Kyle"])
         try expect(result) == "Hello World"
     }
   }

--- a/Tests/StencilTests/TemplateSpec.swift
+++ b/Tests/StencilTests/TemplateSpec.swift
@@ -6,13 +6,13 @@ final class TemplateTests: XCTestCase {
   func testTemplate() {
     it("can render a template from a string") {
       let template = Template(templateString: "Hello World")
-      let result = try template.render([ "name": "Kyle" ])
+      let result = try template.render(object:[ "name": "Kyle" ])
       try expect(result) == "Hello World"
     }
 
     it("can render a template from a string literal") {
         let template: Template = "Hello World"
-        let result = try template.render([ "name": "Kyle" ])
+        let result = try template.render(object:[ "name": "Kyle" ])
         try expect(result) == "Hello World"
     }
   }


### PR DESCRIPTION
Given Mirror is being used to serialize objects that are members of the Context dictionary, it only seems logical we shouldn't be limited to initializing a Context with a dictionary. This PR adds the ability to initialize a context with Any

Initialize Context with Any by converting to dictionary
Allow Any to be pushed onto a Context in a similar way
Change Environment functions to use these new functions