### PR TITLE
Trim whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@
   [Ilya Puchka](https://github.com/ilyapuchka)
   [#219](https://github.com/stencilproject/Stencil/issues/219)
   [#246](https://github.com/stencilproject/Stencil/pull/246)
+- Added support for trimming whitespace around blocks with Jinja2 whitespace control symbols. eg `{%- if value +%}`.  
+  [Miguel Bejar](https://github.com/bejar37)
+  [Yonas Kolb](https://github.com/yonaskolb)
+  [#92](https://github.com/stencilproject/Stencil/pull/92)
+  [#287](https://github.com/stencilproject/Stencil/pull/287)
+- Added support for adding default whitespace trimming behaviour to an environment.  
+  [Yonas Kolb](https://github.com/yonaskolb)
+  [#287](https://github.com/stencilproject/Stencil/pull/287)
 
 ### Deprecations
 

--- a/Sources/Stencil/Environment.swift
+++ b/Sources/Stencil/Environment.swift
@@ -4,6 +4,8 @@ public struct Environment {
   public let templateClass: Template.Type
   /// List of registered extensions
   public var extensions: [Extension]
+  /// How to handle whitespace
+  public var trimBehaviour: TrimBehaviour
   /// Mechanism for loading new files
   public var loader: Loader?
 
@@ -13,14 +15,17 @@ public struct Environment {
   ///  - loader: Mechanism for loading new files
   ///  - extensions: List of extension containers
   ///  - templateClass: Class for newly loaded templates
+  ///  - trimBehaviour: How to handle whitespace
   public init(
     loader: Loader? = nil,
     extensions: [Extension] = [],
-    templateClass: Template.Type = Template.self
+    templateClass: Template.Type = Template.self,
+    trimBehaviour: TrimBehaviour = .nothing
   ) {
     self.templateClass = templateClass
     self.loader = loader
     self.extensions = extensions + [DefaultExtension()]
+    self.trimBehaviour = trimBehaviour
   }
 
   /// Load a template with the given name

--- a/Sources/Stencil/Node.swift
+++ b/Sources/Stencil/Node.swift
@@ -41,14 +41,27 @@ public class SimpleNode: NodeType {
 public class TextNode: NodeType {
   public let text: String
   public let token: Token?
+  public let trimBehaviour: TrimBehaviour
 
-  public init(text: String) {
+  public init(text: String, trimBehaviour: TrimBehaviour = .nothing) {
     self.text = text
     self.token = nil
+    self.trimBehaviour = trimBehaviour
   }
 
   public func render(_ context: Context) throws -> String {
-    self.text
+    var string = self.text
+    if trimBehaviour.leading != .nothing, !string.isEmpty {
+      let range = NSRange(..<string.endIndex, in: string)
+      string = TrimBehaviour.leadingRegex(trim: trimBehaviour.leading)
+        .stringByReplacingMatches(in: string, options: [], range: range, withTemplate: "")
+    }
+    if trimBehaviour.trailing != .nothing, !string.isEmpty {
+      let range = NSRange(..<string.endIndex, in: string)
+      string = TrimBehaviour.trailingRegex(trim: trimBehaviour.trailing)
+        .stringByReplacingMatches(in: string, options: [], range: range, withTemplate: "")
+    }
+    return string
   }
 }
 

--- a/Sources/Stencil/Tokenizer.swift
+++ b/Sources/Stencil/Tokenizer.swift
@@ -79,6 +79,19 @@ public struct SourceMap: Equatable {
   }
 }
 
+public struct WhitespaceBehaviour: Equatable {
+  public enum Behaviour {
+    case unspecified
+    case trim
+    case keep
+  }
+
+  let leading: Behaviour
+  let trailing: Behaviour
+
+  public static let unspecified = WhitespaceBehaviour(leading: .unspecified, trailing: .unspecified)
+}
+
 public class Token: Equatable {
   public enum Kind: Equatable {
     /// A token representing a piece of text.
@@ -94,14 +107,16 @@ public class Token: Equatable {
   public let contents: String
   public let kind: Kind
   public let sourceMap: SourceMap
+  public var whitespace: WhitespaceBehaviour?
 
   /// Returns the underlying value as an array seperated by spaces
   public private(set) lazy var components: [String] = self.contents.smartSplit()
 
-  init(contents: String, kind: Kind, sourceMap: SourceMap) {
+  init(contents: String, kind: Kind, sourceMap: SourceMap, whitespace: WhitespaceBehaviour? = nil) {
     self.contents = contents
     self.kind = kind
     self.sourceMap = sourceMap
+    self.whitespace = whitespace
   }
 
   /// A token representing a piece of text.
@@ -120,8 +135,12 @@ public class Token: Equatable {
   }
 
   /// A token representing a template block.
-  public static func block(value: String, at sourceMap: SourceMap) -> Token {
-    Token(contents: value, kind: .block, sourceMap: sourceMap)
+  public static func block(
+    value: String,
+    at sourceMap: SourceMap,
+    whitespace: WhitespaceBehaviour = .unspecified
+  ) -> Token {
+    Token(contents: value, kind: .block, sourceMap: sourceMap, whitespace: whitespace)
   }
 
   public static func == (lhs: Token, rhs: Token) -> Bool {

--- a/Sources/Stencil/TrimBehaviour.swift
+++ b/Sources/Stencil/TrimBehaviour.swift
@@ -1,0 +1,70 @@
+import Foundation
+
+public struct TrimBehaviour: Equatable {
+  var leading: Trim
+  var trailing: Trim
+
+  public enum Trim {
+    /// nothing
+    case nothing
+
+    /// tabs and spaces
+    case whitespace
+
+    /// tabs and spaces and a single new line
+    case whitespaceAndOneNewLine
+
+    /// all tabs spaces and newlines
+    case whitespaceAndNewLines
+  }
+
+  public init(leading: Trim, trailing: Trim) {
+    self.leading = leading
+    self.trailing = trailing
+  }
+
+  /// doesn't touch newlines
+  public static let nothing = TrimBehaviour(leading: .nothing, trailing: .nothing)
+
+  /// removes whitespace before a block and whitespace and a single newline after a block
+  public static let smart = TrimBehaviour(leading: .whitespace, trailing: .whitespaceAndOneNewLine)
+
+  /// removes all whitespace and newlines before and after a block
+  public static let all = TrimBehaviour(leading: .whitespaceAndNewLines, trailing: .whitespaceAndNewLines)
+
+  static func leadingRegex(trim: Trim) -> NSRegularExpression {
+    switch trim {
+    case .nothing:
+      fatalError("No RegularExpression for none")
+    case .whitespace:
+      return Self.leadingWhitespace
+    case .whitespaceAndOneNewLine:
+      return Self.leadingWhitespaceAndOneNewLine
+    case .whitespaceAndNewLines:
+      return Self.leadingWhitespaceAndNewlines
+    }
+  }
+
+  static func trailingRegex(trim: Trim) -> NSRegularExpression {
+    switch trim {
+    case .nothing:
+      fatalError("No RegularExpression for none")
+    case .whitespace:
+      return Self.trailingWhitespace
+    case .whitespaceAndOneNewLine:
+      return Self.trailingWhitespaceAndOneNewLine
+    case .whitespaceAndNewLines:
+      return Self.trailingWhitespaceAndNewLines
+    }
+  }
+
+  // swiftlint:disable force_try
+  private static let leadingWhitespaceAndNewlines = try! NSRegularExpression(pattern: "^\\s+")
+  private static let trailingWhitespaceAndNewLines = try! NSRegularExpression(pattern: "\\s+$")
+
+  private static let leadingWhitespaceAndOneNewLine = try! NSRegularExpression(pattern: "^[ \t]*\n")
+  private static let trailingWhitespaceAndOneNewLine = try! NSRegularExpression(pattern: "\n[ \t]*$")
+
+  private static let leadingWhitespace = try! NSRegularExpression(pattern: "^[ \t]*")
+  private static let trailingWhitespace = try! NSRegularExpression(pattern: "[ \t]*$")
+}

--- a/Tests/StencilTests/NodeSpec.swift
+++ b/Tests/StencilTests/NodeSpec.swift
@@ -14,6 +14,48 @@ final class NodeTests: XCTestCase {
       let node = TextNode(text: "Hello World")
       try expect(try node.render(self.context)) == "Hello World"
     }
+    it("Trims leading whitespace") {
+      let text = "      \n Some text     "
+      let trimBehaviour = TrimBehaviour(leading: .whitespace, trailing: .nothing)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "\n Some text     "
+    }
+    it("Trims leading whitespace and one newline") {
+      let text = "\n\n Some text     "
+      let trimBehaviour = TrimBehaviour(leading: .whitespaceAndOneNewLine, trailing: .nothing)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "\n Some text     "
+    }
+    it("Trims leading whitespace and one newline") {
+      let text = "\n\n Some text     "
+      let trimBehaviour = TrimBehaviour(leading: .whitespaceAndNewLines, trailing: .nothing)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "Some text     "
+    }
+    it("Trims trailing whitespace") {
+      let text = "      Some text     \n"
+      let trimBehaviour = TrimBehaviour(leading: .nothing, trailing: .whitespace)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "      Some text\n"
+    }
+    it("Trims trailing whitespace and one newline") {
+      let text = "      Some text     \n \n "
+      let trimBehaviour = TrimBehaviour(leading: .nothing, trailing: .whitespaceAndOneNewLine)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "      Some text     \n "
+    }
+    it("Trims trailing whitespace and newlines") {
+      let text = "      Some text     \n \n "
+      let trimBehaviour = TrimBehaviour(leading: .nothing, trailing: .whitespaceAndNewLines)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "      Some text"
+    }
+    it("Trims all whitespace") {
+      let text = "    \n  \nSome text \n    "
+      let trimBehaviour = TrimBehaviour(leading: .whitespaceAndNewLines, trailing: .whitespaceAndNewLines)
+      let node = TextNode(text: text, trimBehaviour: trimBehaviour)
+      try expect(try node.render(self.context)) == "Some text"
+    }
   }
 
   func testVariableNode() {

--- a/Tests/StencilTests/ParserSpec.swift
+++ b/Tests/StencilTests/ParserSpec.swift
@@ -3,62 +3,77 @@ import Spectre
 import XCTest
 
 final class TokenParserTests: XCTestCase {
-  func testTokenParser() {
-    it("can parse a text token") {
-      let parser = TokenParser(tokens: [
-        .text(value: "Hello World", at: .unknown)
-      ], environment: Environment())
+  func testTextToken() throws {
+    let parser = TokenParser(tokens: [
+      .text(value: "Hello World", at: .unknown)
+    ], environment: Environment())
 
-      let nodes = try parser.parse()
-      let node = nodes.first as? TextNode
+    let nodes = try parser.parse()
+    let node = nodes.first as? TextNode
 
-      try expect(nodes.count) == 1
-      try expect(node?.text) == "Hello World"
+    try expect(nodes.count) == 1
+    try expect(node?.text) == "Hello World"
+  }
+
+  func testVariableToken() throws {
+    let parser = TokenParser(tokens: [
+      .variable(value: "'name'", at: .unknown)
+    ], environment: Environment())
+
+    let nodes = try parser.parse()
+    let node = nodes.first as? VariableNode
+    try expect(nodes.count) == 1
+    let result = try node?.render(Context())
+    try expect(result) == "name"
+  }
+
+  func testCommentToken() throws {
+    let parser = TokenParser(tokens: [
+      .comment(value: "Secret stuff!", at: .unknown)
+    ], environment: Environment())
+
+    let nodes = try parser.parse()
+    try expect(nodes.count) == 0
+  }
+
+  func testTagToken() throws {
+    let simpleExtension = Extension()
+    simpleExtension.registerSimpleTag("known") { _ in
+      ""
     }
 
-    it("can parse a variable token") {
-      let parser = TokenParser(tokens: [
-        .variable(value: "'name'", at: .unknown)
-      ], environment: Environment())
+    let parser = TokenParser(tokens: [
+      .block(value: "known", at: .unknown)
+    ], environment: Environment(extensions: [simpleExtension]))
 
-      let nodes = try parser.parse()
-      let node = nodes.first as? VariableNode
-      try expect(nodes.count) == 1
-      let result = try node?.render(Context())
-      try expect(result) == "name"
-    }
+    let nodes = try parser.parse()
+    try expect(nodes.count) == 1
+  }
 
-    it("can parse a comment token") {
-      let parser = TokenParser(tokens: [
-        .comment(value: "Secret stuff!", at: .unknown)
-      ], environment: Environment())
+  func testErrorUnknownTag() throws {
+    let tokens: [Token] = [.block(value: "unknown", at: .unknown)]
+    let parser = TokenParser(tokens: tokens, environment: Environment())
 
-      let nodes = try parser.parse()
-      try expect(nodes.count) == 0
-    }
+    try expect(try parser.parse()).toThrow(TemplateSyntaxError(
+      reason: "Unknown template tag 'unknown'",
+      token: tokens.first
+    ))
+  }
 
-    it("can parse a tag token") {
-      let simpleExtension = Extension()
-      simpleExtension.registerSimpleTag("known") { _ in
-        ""
-      }
+  func testTransformWhitespaceBehaviourToTrimBehaviour() throws {
+    let simpleExtension = Extension()
+    simpleExtension.registerSimpleTag("known") { _ in "" }
 
-      let parser = TokenParser(tokens: [
-        .block(value: "known", at: .unknown)
-      ], environment: Environment(extensions: [simpleExtension]))
+    let parser = TokenParser(tokens: [
+      .block(value: "known", at: .unknown, whitespace: WhitespaceBehaviour(leading: .unspecified, trailing: .trim)),
+      .text(value: "      \nSome text     ", at: .unknown),
+      .block(value: "known", at: .unknown, whitespace: WhitespaceBehaviour(leading: .keep, trailing: .trim))
+    ], environment: Environment(extensions: [simpleExtension]))
 
-      let nodes = try parser.parse()
-      try expect(nodes.count) == 1
-    }
-
-    it("errors when parsing an unknown tag") {
-      let tokens: [Token] = [.block(value: "unknown", at: .unknown)]
-      let parser = TokenParser(tokens: tokens, environment: Environment())
-
-      try expect(try parser.parse()).toThrow(TemplateSyntaxError(
-        reason: "Unknown template tag 'unknown'",
-        token: tokens.first
-      ))
-    }
+    let nodes = try parser.parse()
+    try expect(nodes.count) == 3
+    let textNode = nodes[1] as? TextNode
+    try expect(textNode?.text) == "      \nSome text     "
+    try expect(textNode?.trimBehaviour) == TrimBehaviour(leading: .whitespaceAndNewLines, trailing: .nothing)
   }
 }

--- a/Tests/StencilTests/TrimBehaviourSpec.swift
+++ b/Tests/StencilTests/TrimBehaviourSpec.swift
@@ -1,0 +1,137 @@
+import Spectre
+import Stencil
+import XCTest
+
+final class TrimBehaviourTests: XCTestCase {
+  func testSmartTrimCanRemoveNewlines() throws {
+    let templateString = """
+      {% for item in items %}
+        - {{item}}
+      {% endfor %}
+      text
+      """
+
+    let context = ["items": ["item 1", "item 2"]]
+    let template = Template(templateString: templateString, environment: .init(trimBehaviour: .smart))
+    let result = try template.render(context)
+
+    // swiftlint:disable indentation_width
+    try expect(result) == """
+        - item 1
+        - item 2
+      text
+      """
+    // swiftlint:enable indentation_width
+  }
+
+  func testSmartTrimOnlyRemoveSingleNewlines() throws {
+    let templateString = """
+      {% for item in items %}
+
+        - {{item}}
+      {% endfor %}
+      text
+      """
+
+    let context = ["items": ["item 1", "item 2"]]
+    let template = Template(templateString: templateString, environment: .init(trimBehaviour: .smart))
+    let result = try template.render(context)
+
+    // swiftlint:disable indentation_width
+    try expect(result) == """
+
+        - item 1
+
+        - item 2
+      text
+      """
+    // swiftlint:enable indentation_width
+  }
+
+  func testSmartTrimCanRemoveNewlinesWhileKeepingWhitespace() throws {
+    // swiftlint:disable indentation_width
+    let templateString = """
+          Items:
+          {% for item in items %}
+              - {{item}}
+          {% endfor %}
+      """
+    // swiftlint:enable indentation_width
+
+    let context = ["items": ["item 1", "item 2"]]
+    let template = Template(templateString: templateString, environment: .init(trimBehaviour: .smart))
+    let result = try template.render(context)
+
+    // swiftlint:disable indentation_width
+    try expect(result) == """
+          Items:
+              - item 1
+              - item 2
+
+      """
+    // swiftlint:enable indentation_width
+  }
+
+  func testTrimSymbols() {
+    it("Respects whitespace control symbols in for tags") {
+      // swiftlint:disable indentation_width
+      let template: Template = """
+        {% for num in numbers -%}
+            {{num}}
+        {%- endfor %}
+        """
+      // swiftlint:enable indentation_width
+      let result = try template.render([ "numbers": Array(1...9) ])
+      try expect(result) == "123456789"
+    }
+    it("Respects whitespace control symbols in if tags") {
+      let template: Template = """
+        {% if value -%}
+          {{text}}
+        {%- endif %}
+        """
+      let result = try template.render([ "text": "hello", "value": true ])
+      try expect(result) == "hello"
+    }
+  }
+
+  func testTrimSymbolsOverridingEnvironment() {
+    let environment = Environment(trimBehaviour: .all)
+
+    it("respects whitespace control symbols in if tags") {
+      // swiftlint:disable indentation_width
+      let templateString = """
+          {% if value +%}
+          {{text}}
+        {%+ endif %}
+
+        """
+      // swiftlint:enable indentation_width
+      let template = Template(templateString: templateString, environment: environment)
+      let result = try template.render([ "text": "hello", "value": true ])
+      try expect(result) == "\n  hello\n"
+    }
+
+    it("can customize blocks on same line as text") {
+      // swiftlint:disable indentation_width
+      let templateString = """
+            Items:{% for item in items +%}
+                - {{item}}
+            {%- endfor %}
+        """
+      // swiftlint:enable indentation_width
+
+      let context = ["items": ["item 1", "item 2"]]
+      let template = Template(templateString: templateString, environment: environment)
+      let result = try template.render(context)
+
+      // swiftlint:disable indentation_width
+      try expect(result) == """
+            Items:
+                - item 1
+                - item 2
+        """
+      // swiftlint:enable indentation_width
+    }
+  }
+}

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -97,6 +97,17 @@ To comment out part of your template, you can use the following syntax:
 
 .. _template-inheritance:
 
+Whitespace Control
+------------------
+
+Stencil supports the same syntax as Jinja for whitespace control, see [their docs for more information](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control).
+
+Essentially, Stencil will **not** trim whitespace by default. However you can:
+
+- Control how this is handled for the whole template by setting the trim behaviour. We provide a few pre-made combinations such as `nothing` (default), `smart` and `all`. More granular combinations are possible.
+- You can disable this per-block using the `+` control character. For example `{{+ if … }}` to preserve whitespace before.
+- You can force trimming per-block by using the `-` control character. For example `{{ if … -}}` to trim whitespace after.
+
 Template inheritance
 --------------------
 


### PR DESCRIPTION
This takes the work that @bejar37 started in #92 and builds upon it.

In addition to the Jinja2 trimming symbols, this adds a `trimBehavior: TrimBehaviour` on `Environment`. This defaults to `.none` but can be customized. It also comes with a built in `.smart` case that removes whitespace before a block, and whitespace and a single newline after a block.