### PR TITLE
Fix articles example in the documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ feel right at home with Stencil.
     ]
 
     let environment = Environment(loader: FileSystemLoader(paths: ["templates/"])
-    let rendered = try environment.renderTemplate(name: context)
+    let rendered = try environment.renderTemplate(name: "articles.html", context: context)
 
     print(rendered)
 


### PR DESCRIPTION
Context was being passed as the name param to `renderTemplate`, but it should be an actual name.