### PR TITLE
Update PathKit in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     .library(name: "Stencil", targets: ["Stencil"])
   ],
   dependencies: [
-    .package(url: "https://github.com/kylef/PathKit.git", from: "0.9.0"),
+    .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.0"),
     .package(url: "https://github.com/kylef/Spectre.git", from: "0.9.0")
   ],
   targets: [


### PR DESCRIPTION
`Package@swift-5.swift` has a newer version of `PathKit` than `Package.swift` where `Package.swift` contains an outdated reference to `PathKit` `0.9.0`.

I think it'd make sense to update it 🙂 