### PR TITLE
Fix build warning

### DIFF
--- a/Sources/Node.swift
+++ b/Sources/Node.swift
@@ -60,7 +60,7 @@ public class VariableNode: NodeType {
   let elseExpression: Resolvable?
 
   class func parse(_ parser: TokenParser, token: Token) throws -> NodeType {
-    var components = token.components
+    let components = token.components
 
     func hasToken(_ token: String, at index: Int) -> Bool {
       return components.count > (index + 1) && components[index] == token


### PR DESCRIPTION
`components` is not mutated, so it can be a `let`. This fixes the build warning that otherwise shows up in build logs.