### PR TITLE
Fix for crashing range indexes when variable length is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ _None_
 - Throw syntax error on empty variable tags (`{{ }}`) instead `fatalError`.  
   [Ilya Puchka](https://github.com/ilyapuchka)
   [#263](https://github.com/stencilproject/Stencil/pull/263)
+- Fix for crashing range indexes when variable length is 1.  
+  [Łukasz Kuczborski](https://github.com/lkuczborski)
+  [#306](https://github.com/stencilproject/Stencil/pull/306)
 
 ### Internal Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix for crashing range indexes when variable length is 1.  
+  [Łukasz Kuczborski](https://github.com/lkuczborski)
+  [#306](https://github.com/stencilproject/Stencil/pull/306)
 
 ### Internal Changes
 
@@ -49,9 +51,6 @@ _None_
 - Throw syntax error on empty variable tags (`{{ }}`) instead `fatalError`.  
   [Ilya Puchka](https://github.com/ilyapuchka)
   [#263](https://github.com/stencilproject/Stencil/pull/263)
-- Fix for crashing range indexes when variable length is 1.  
-  [Łukasz Kuczborski](https://github.com/lkuczborski)
-  [#306](https://github.com/stencilproject/Stencil/pull/306)
 
 ### Internal Changes
 

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -48,10 +48,11 @@ public struct Variable: Equatable, Resolvable {
 
   /// Resolve the variable in the given context
   public func resolve(_ context: Context) throws -> Any? {
-    if (variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\"")) {
+    if variable.count > 1 && (variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\"")) {
       // String literal
-      guard variable.count > 1 else { return "" }
       return String(variable[variable.index(after: variable.startIndex) ..< variable.index(before: variable.endIndex)])
+    } else {
+      return ""
     }
 
     // Number literal

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -51,8 +51,6 @@ public struct Variable: Equatable, Resolvable {
     if variable.count > 1 && ((variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\""))) {
       // String literal
       return String(variable[variable.index(after: variable.startIndex) ..< variable.index(before: variable.endIndex)])
-    } else {
-      return ""
     }
 
     // Number literal

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -50,6 +50,7 @@ public struct Variable: Equatable, Resolvable {
   public func resolve(_ context: Context) throws -> Any? {
     if (variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\"")) {
       // String literal
+      guard variable.count > 1 else { return "" }
       return String(variable[variable.index(after: variable.startIndex) ..< variable.index(before: variable.endIndex)])
     }
 

--- a/Sources/Variable.swift
+++ b/Sources/Variable.swift
@@ -48,7 +48,7 @@ public struct Variable: Equatable, Resolvable {
 
   /// Resolve the variable in the given context
   public func resolve(_ context: Context) throws -> Any? {
-    if variable.count > 1 && (variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\"")) {
+    if variable.count > 1 && ((variable.hasPrefix("'") && variable.hasSuffix("'")) || (variable.hasPrefix("\"") && variable.hasSuffix("\""))) {
       // String literal
       return String(variable[variable.index(after: variable.startIndex) ..< variable.index(before: variable.endIndex)])
     } else {

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -67,7 +67,7 @@ final class VariableTests: XCTestCase {
     it("can resolve a string literal with one double quote") {
       let variable = Variable("\"")
       let result = try variable.resolve(self.context) as? String
-      try expect(result) == ""
+      try expect(result).to.beNil()
     }
 
     it("can resolve a string literal with single quotes") {
@@ -79,7 +79,7 @@ final class VariableTests: XCTestCase {
     it("can resolve a string literal with one single quote") {
       let variable = Variable("'")
       let result = try variable.resolve(self.context) as? String
-      try expect(result) == ""
+      try expect(result).to.beNil()
     }
     
     it("can resolve an integer literal") {

--- a/Tests/StencilTests/VariableSpec.swift
+++ b/Tests/StencilTests/VariableSpec.swift
@@ -63,13 +63,25 @@ final class VariableTests: XCTestCase {
       let result = try variable.resolve(self.context) as? String
       try expect(result) == "name"
     }
+    
+    it("can resolve a string literal with one double quote") {
+      let variable = Variable("\"")
+      let result = try variable.resolve(self.context) as? String
+      try expect(result) == ""
+    }
 
     it("can resolve a string literal with single quotes") {
       let variable = Variable("'name'")
       let result = try variable.resolve(self.context) as? String
       try expect(result) == "name"
     }
-
+    
+    it("can resolve a string literal with one single quote") {
+      let variable = Variable("'")
+      let result = try variable.resolve(self.context) as? String
+      try expect(result) == ""
+    }
+    
     it("can resolve an integer literal") {
       let variable = Variable("5")
       let result = try variable.resolve(self.context) as? Int


### PR DESCRIPTION
This PR fixes a crash when variable length equals 1 - one single quote (') or one double quote("):
`Fatal error: Can't form Range with upperBound < lowerBound: file Swift/x86_64-apple-macos.swiftinterface, line 14814`