### PR TITLE
Make `render` method public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ _None_
 - Made the `tokens` property on a `Template` public.  
   [Stefanomondino](https://github.com/stefanomondino)
   [#292](https://github.com/stencilproject/Stencil/pull/292)
+- Made the `Template.render(_:)` method (that accepts a `Context`) public.  
+  [David Jennes](https://github.com/djbe)
+  [#322](https://github.com/stencilproject/Stencil/pull/322)
 
 ### Deprecations
 

--- a/Sources/Template.swift
+++ b/Sources/Template.swift
@@ -67,7 +67,7 @@ open class Template: ExpressibleByStringLiteral {
   }
 
   /// Render the given template with a context
-  func render(_ context: Context) throws -> String {
+  public func render(_ context: Context) throws -> String {
     let context = context
     let parser = TokenParser(tokens: tokens, environment: context.environment)
     let nodes = try parser.parse()


### PR DESCRIPTION
Needed for features like https://github.com/SwiftGen/StencilSwiftKit/pull/111, where the user wants to provide their own `Context` object (reference) instead of a dictionary.

Reason for this is that the method with dictionary will work on a copy, whereas the `Context` one will work on a reference, storing the changes.