### PR TITLE
Resolvable boolean expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 - You can now access outer loop's scope by labeling it: `{% outer: for ... %}... {% for ... %} {{ outer.counter }} {% endfor %}{% endfor %}`.  
   [Ilya Puchka](https://github.com/ilyapuchka)
   [#175](https://github.com/stencilproject/Stencil/pull/175)
+- Boolean expressions can now be rendered, i.e `{{ name == "John" }}` will render `true` or `false` depending on the evaluation result.  
+  [Ilya Puchka](https://github.com/ilyapuchka)
+  [David Jennes](https://github.com/djbe)
+  [#164](https://github.com/stencilproject/Stencil/pull/164)
+  [#325](https://github.com/stencilproject/Stencil/pull/325)
 
 ### Deprecations
 

--- a/Sources/Stencil/Expression.swift
+++ b/Sources/Stencil/Expression.swift
@@ -1,5 +1,11 @@
-public protocol Expression: CustomStringConvertible {
+public protocol Expression: CustomStringConvertible, Resolvable {
   func evaluate(context: Context) throws -> Bool
+}
+
+extension Expression {
+  func resolve(_ context: Context) throws -> Any? {
+    try "\(evaluate(context: context))"
+  }
 }
 
 protocol InfixOperator: Expression {
@@ -37,8 +43,12 @@ final class VariableExpression: Expression, CustomStringConvertible {
     "(variable: \(variable))"
   }
 
+  func resolve(_ context: Context) throws -> Any? {
+    try variable.resolve(context)
+  }
+
   /// Resolves a variable in the given context as boolean
-  func resolve(context: Context, variable: Resolvable) throws -> Bool {
+  func evaluate(context: Context) throws -> Bool {
     let result = try variable.resolve(context)
     var truthy = false
 
@@ -57,10 +67,6 @@ final class VariableExpression: Expression, CustomStringConvertible {
     }
 
     return truthy
-  }
-
-  func evaluate(context: Context) throws -> Bool {
-    try resolve(context: context, variable: variable)
   }
 }
 

--- a/Tests/StencilTests/ExpressionSpec.swift
+++ b/Tests/StencilTests/ExpressionSpec.swift
@@ -115,12 +115,12 @@ final class ExpressionsTests: XCTestCase {
 
   func testNotExpression() {
     it("returns truthy for positive expressions") {
-      let expression = NotExpression(expression: StaticExpression(value: true))
+      let expression = NotExpression(expression: VariableExpression(variable: Variable("true")))
       try expect(expression.evaluate(context: Context())).to.beFalse()
     }
 
     it("returns falsy for negative expressions") {
-      let expression = NotExpression(expression: StaticExpression(value: false))
+      let expression = NotExpression(expression: VariableExpression(variable: Variable("false")))
       try expect(expression.evaluate(context: Context())).to.beTrue()
     }
   }

--- a/Tests/StencilTests/IfNodeSpec.swift
+++ b/Tests/StencilTests/IfNodeSpec.swift
@@ -200,8 +200,8 @@ final class IfNodeTests: XCTestCase {
   func testRendering() {
     it("renders a true expression") {
       let node = IfNode(conditions: [
-        IfCondition(expression: StaticExpression(value: true), nodes: [TextNode(text: "1")]),
-        IfCondition(expression: StaticExpression(value: true), nodes: [TextNode(text: "2")]),
+        IfCondition(expression: VariableExpression(variable: Variable("true")), nodes: [TextNode(text: "1")]),
+        IfCondition(expression: VariableExpression(variable: Variable("true")), nodes: [TextNode(text: "2")]),
         IfCondition(expression: nil, nodes: [TextNode(text: "3")])
       ])
 
@@ -210,8 +210,8 @@ final class IfNodeTests: XCTestCase {
 
     it("renders the first true expression") {
       let node = IfNode(conditions: [
-        IfCondition(expression: StaticExpression(value: false), nodes: [TextNode(text: "1")]),
-        IfCondition(expression: StaticExpression(value: true), nodes: [TextNode(text: "2")]),
+        IfCondition(expression: VariableExpression(variable: Variable("false")), nodes: [TextNode(text: "1")]),
+        IfCondition(expression: VariableExpression(variable: Variable("true")), nodes: [TextNode(text: "2")]),
         IfCondition(expression: nil, nodes: [TextNode(text: "3")])
       ])
 
@@ -220,8 +220,8 @@ final class IfNodeTests: XCTestCase {
 
     it("renders the empty expression when other conditions are falsy") {
       let node = IfNode(conditions: [
-        IfCondition(expression: StaticExpression(value: false), nodes: [TextNode(text: "1")]),
-        IfCondition(expression: StaticExpression(value: false), nodes: [TextNode(text: "2")]),
+        IfCondition(expression: VariableExpression(variable: Variable("false")), nodes: [TextNode(text: "1")]),
+        IfCondition(expression: VariableExpression(variable: Variable("false")), nodes: [TextNode(text: "2")]),
         IfCondition(expression: nil, nodes: [TextNode(text: "3")])
       ])
 
@@ -230,8 +230,8 @@ final class IfNodeTests: XCTestCase {
 
     it("renders empty when no truthy conditions") {
       let node = IfNode(conditions: [
-        IfCondition(expression: StaticExpression(value: false), nodes: [TextNode(text: "1")]),
-        IfCondition(expression: StaticExpression(value: false), nodes: [TextNode(text: "2")])
+        IfCondition(expression: VariableExpression(variable: Variable("false")), nodes: [TextNode(text: "1")]),
+        IfCondition(expression: VariableExpression(variable: Variable("false")), nodes: [TextNode(text: "2")])
       ])
 
       try expect(try node.render(Context())) == ""

--- a/Tests/StencilTests/NodeSpec.swift
+++ b/Tests/StencilTests/NodeSpec.swift
@@ -90,4 +90,22 @@ final class NodeTests: XCTestCase {
       try expect(try renderNodes(nodes, self.context)).toThrow(TemplateSyntaxError("Custom Error"))
     }
   }
+
+  func testRenderingBooleans() {
+    it("can render true & false") {
+      try expect(Template(templateString: "{{ true }}").render()) == "true"
+      try expect(Template(templateString: "{{ false }}").render()) == "false"
+    }
+
+    it("can resolve variable") {
+      let template = Template(templateString: "{{ value == \"known\" }}")
+      try expect(template.render(["value": "known"])) == "true"
+      try expect(template.render(["value": "unknown"])) == "false"
+    }
+
+    it("can render a boolean expression") {
+      try expect(Template(templateString: "{{ 1 > 0 }}").render()) == "true"
+      try expect(Template(templateString: "{{ 1 == 2 }}").render()) == "false"
+    }
+  }
 }

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -50,6 +50,17 @@ For example, if you have the following context:
 
     The result of {{ item[key] }} will be the same as {{ item.name }}. It will first evaluate the result of {{ key }}, and only then evaluate the lookup expression.
 
+Boolean expressions
+-------------------
+
+Boolean expressions can be rendered using ``{{ ... }}`` tag.
+For example, this will output string `true` if variable is equal to 1 and `false` otherwise:
+
+.. code-block:: html+django
+
+    {{ variable == 1 }}
+
+
 Filters
 ~~~~~~~
 


### PR DESCRIPTION
Reopening #164, as it's been rebased on master, and the failing tests have been fixed.

The issue was that the old PR was replacing all our logic in `VariableNode.parse(:token:)` with a simple `compileExpression` + `compileFilter`. This PR moves those 2 into that function, so that it also applies to `… if … else …` expressions.