### PR TITLE
Fix `LazyValueWrapper`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ _None_
 
 ### Bug Fixes
 
-_None_
+- Fix bug in `LazyValueWrapper`, causing it to never resolve.  
+  [David Jennes](https://github.com/djbe)
+  [#328](https://github.com/stencilproject/Stencil/pull/328)
 
 ### Internal Changes
 

--- a/Sources/Stencil/LazyValueWrapper.swift
+++ b/Sources/Stencil/LazyValueWrapper.swift
@@ -61,9 +61,3 @@ extension LazyValueWrapper: Resolvable {
     return try (value as? Resolvable)?.resolve(context) ?? value
   }
 }
-
-extension LazyValueWrapper: Normalizable {
-  public func normalize() -> Any? {
-    (cachedValue as? Normalizable)?.normalize() ?? cachedValue
-  }
-}


### PR DESCRIPTION
I apparently misunderstood what the `Normalizable` protocol did, it was never needed for this data structure.