### PR TITLE
Stencil: use unstable features for portability

### DIFF
--- a/Sources/Stencil/Variable.swift
+++ b/Sources/Stencil/Variable.swift
@@ -111,12 +111,12 @@ public struct Variable: Equatable, Resolvable {
     } else if let string = context as? String {
       return resolve(bit: bit, collection: string)
     } else if let object = context as? NSObject {  // NSKeyValueCoding
-      #if os(Linux)
-        return nil
-      #else
+      #if _runtime(_ObjC)
         if object.responds(to: Selector(bit)) {
           return object.value(forKey: bit)
         }
+      #else
+        return nil
       #endif
     } else if let value = context as? DynamicMemberLookup {
       return value[dynamicMember: bit]


### PR DESCRIPTION
Rather than exhaustively enumerating via OS use the unstable feature to detect if ObjC interop is enabled.  This allows building on Windows.

Unfortunately, the entire test suite does not pass on Windows, with path issues due to PathKit's handling of paths.