### PR TITLE
Prefer DynamicMemberLookup over KVC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.15.2
+
+### Enhancements
+
+- Prefer `DynamicMemberLookup` over KVC.  
+  [##342](https://github.com/stencilproject/Stencil/pull/342)
+  [@art-divin](https://github.com/art-divin)
+
 ## 0.15.1
 
 ### Bug Fixes
@@ -5,9 +13,6 @@
 - Fix bug in `LazyValueWrapper`, causing it to never resolve.  
   [David Jennes](https://github.com/djbe)
   [#328](https://github.com/stencilproject/Stencil/pull/328)
-- Prefer `DynamicMemberLookup` over KVC.  
-  [##342](https://github.com/stencilproject/Stencil/pull/342)
-  [@art-divin](https://github.com/art-divin)
 
 ## 0.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Fix bug in `LazyValueWrapper`, causing it to never resolve.  
   [David Jennes](https://github.com/djbe)
   [#328](https://github.com/stencilproject/Stencil/pull/328)
+- Prefer `DynamicMemberLookup` over KVC.  
+  [##342](https://github.com/stencilproject/Stencil/pull/342)
+  [@art-divin](https://github.com/art-divin)
 
 ## 0.15.0
 

--- a/Sources/Stencil/Variable.swift
+++ b/Sources/Stencil/Variable.swift
@@ -110,16 +110,16 @@ public struct Variable: Equatable, Resolvable {
       return resolve(bit: bit, collection: array)
     } else if let string = context as? String {
       return resolve(bit: bit, collection: string)
+    } else if let value = context as? DynamicMemberLookup {
+      return value[dynamicMember: bit]
     } else if let object = context as? NSObject {  // NSKeyValueCoding
-      #if os(Linux)
+      #if canImport(ObjectiveC)
         return nil
       #else
         if object.responds(to: Selector(bit)) {
           return object.value(forKey: bit)
         }
       #endif
-    } else if let value = context as? DynamicMemberLookup {
-      return value[dynamicMember: bit]
     } else if let value = context {
       return Mirror(reflecting: value).getValue(for: bit)
     }

--- a/Sources/Stencil/Variable.swift
+++ b/Sources/Stencil/Variable.swift
@@ -113,7 +113,7 @@ public struct Variable: Equatable, Resolvable {
     } else if let value = context as? DynamicMemberLookup {
       return value[dynamicMember: bit]
     } else if let object = context as? NSObject {  // NSKeyValueCoding
-      #if canImport(ObjectiveC)
+      #if !canImport(ObjectiveC)
         return nil
       #else
         if object.responds(to: Selector(bit)) {


### PR DESCRIPTION
## Context

On non-Darwin platforms KVC is not supported, thus check in `Variable.swift:115` is returning `nil`.

While this technically cannot be solved, it would be better  to first attempt to get value via `DynamicMemberLookup` protocol conformance.

This change is required for Sourcery linux support: https://github.com/krzysztofzablocki/Sourcery/pull/1188