### PR TITLE
Windows Support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "PathKit",
-        "repositoryURL": "https://github.com/kylef/PathKit.git",
-        "state": {
-          "branch": null,
-          "revision": "3bfd2737b700b9a36565a8c94f4ad2b050a5e574",
-          "version": "1.0.1"
-        }
-      },
-      {
         "package": "Spectre",
         "repositoryURL": "https://github.com/kylef/Spectre.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -7,13 +7,10 @@ let package = Package(
     .library(name: "Stencil", targets: ["Stencil"])
   ],
   dependencies: [
-    .package(url: "https://github.com/kylef/PathKit.git", from: "1.0.1"),
     .package(url: "https://github.com/kylef/Spectre.git", from: "0.10.1")
   ],
   targets: [
-    .target(name: "Stencil", dependencies: [
-      "PathKit"
-    ]),
+    .target(name: "Stencil"),
     .testTarget(name: "StencilTests", dependencies: [
       "Stencil",
       "Spectre"

--- a/Sources/Stencil/Include.swift
+++ b/Sources/Stencil/Include.swift
@@ -4,8 +4,6 @@
 // MIT Licence
 //
 
-import PathKit
-
 class IncludeNode: NodeType {
   let templateName: Variable
   let includeContext: String?

--- a/Sources/Stencil/Template.swift
+++ b/Sources/Stencil/Template.swift
@@ -5,7 +5,6 @@
 //
 
 import Foundation
-import PathKit
 
 #if os(Linux)
 // swiftlint:disable:next prefixed_toplevel_constant
@@ -41,19 +40,7 @@ open class Template: ExpressibleByStringLiteral {
       throw NSError(domain: NSCocoaErrorDomain, code: NSFileNoSuchFileError, userInfo: nil)
     }
 
-    try self.init(URL: url)
-  }
-
-  /// Create a template with a file found at the given URL
-  @available(*, deprecated, message: "Use Environment/FileSystemLoader instead")
-  public convenience init(URL: Foundation.URL) throws {
-    try self.init(path: Path(URL.path))
-  }
-
-  /// Create a template with a file found at the given path
-  @available(*, deprecated, message: "Use Environment/FileSystemLoader instead")
-  public convenience init(path: Path, environment: Environment? = nil, name: String? = nil) throws {
-    self.init(templateString: try path.read(), environment: environment, name: name)
+    try self.init(templateString: String(contentsOf: url))
   }
 
   // MARK: ExpressibleByStringLiteral

--- a/Sources/Stencil/Variable.swift
+++ b/Sources/Stencil/Variable.swift
@@ -111,12 +111,12 @@ public struct Variable: Equatable, Resolvable {
     } else if let string = context as? String {
       return resolve(bit: bit, collection: string)
     } else if let object = context as? NSObject {  // NSKeyValueCoding
-      #if os(Linux)
-        return nil
-      #else
+      #if _runtime(_ObjC)
         if object.responds(to: Selector(bit)) {
           return object.value(forKey: bit)
         }
+      #else
+        return nil
       #endif
     } else if let value = context as? DynamicMemberLookup {
       return value[dynamicMember: bit]

--- a/Tests/StencilTests/EnvironmentBaseAndChildTemplateSpec.swift
+++ b/Tests/StencilTests/EnvironmentBaseAndChildTemplateSpec.swift
@@ -4,7 +4,6 @@
 // MIT Licence
 //
 
-import PathKit
 import Spectre
 @testable import Stencil
 import XCTest
@@ -17,7 +16,7 @@ final class EnvironmentBaseAndChildTemplateTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    let path = Path(#file as String) + ".." + "fixtures"
+    let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("fixtures")
     let loader = FileSystemLoader(paths: [path])
     environment = Environment(loader: loader)
     childTemplate = ""

--- a/Tests/StencilTests/EnvironmentIncludeTemplateSpec.swift
+++ b/Tests/StencilTests/EnvironmentIncludeTemplateSpec.swift
@@ -4,7 +4,6 @@
 // MIT Licence
 //
 
-import PathKit
 import Spectre
 @testable import Stencil
 import XCTest
@@ -17,7 +16,7 @@ final class EnvironmentIncludeTemplateTests: XCTestCase {
   override func setUp() {
     super.setUp()
 
-    let path = Path(#file as String) + ".." + "fixtures"
+    let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("fixtures")
     let loader = FileSystemLoader(paths: [path])
     environment = Environment(loader: loader)
     template = ""

--- a/Tests/StencilTests/IncludeSpec.swift
+++ b/Tests/StencilTests/IncludeSpec.swift
@@ -4,13 +4,12 @@
 // MIT Licence
 //
 
-import PathKit
 import Spectre
 @testable import Stencil
 import XCTest
 
 final class IncludeTests: XCTestCase {
-  private let path = Path(#file as String) + ".." + "fixtures"
+  private let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("fixtures")
   private lazy var loader = FileSystemLoader(paths: [path])
   private lazy var environment = Environment(loader: loader)
 

--- a/Tests/StencilTests/InheritanceSpec.swift
+++ b/Tests/StencilTests/InheritanceSpec.swift
@@ -4,13 +4,12 @@
 // MIT Licence
 //
 
-import PathKit
 import Spectre
 import Stencil
 import XCTest
 
 final class InheritanceTests: XCTestCase {
-  private let path = Path(#file as String) + ".." + "fixtures"
+  private let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("fixtures")
   private lazy var loader = FileSystemLoader(paths: [path])
   private lazy var environment = Environment(loader: loader)
 

--- a/Tests/StencilTests/LexerSpec.swift
+++ b/Tests/StencilTests/LexerSpec.swift
@@ -4,7 +4,6 @@
 // MIT Licence
 //
 
-import PathKit
 import Spectre
 @testable import Stencil
 import XCTest
@@ -140,8 +139,11 @@ final class LexerTests: XCTestCase {
   }
 
   func testPerformance() throws {
-    let path = Path(#file as String) + ".." + "fixtures" + "huge.html"
-    let content: String = try path.read()
+    let path = URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()
+      .appendingPathComponent("fixtures")
+      .appendingPathComponent("huge.html")
+    let content: String = try String(contentsOf: path)
 
     measure {
       let lexer = Lexer(templateString: content)

--- a/Tests/StencilTests/LoaderSpec.swift
+++ b/Tests/StencilTests/LoaderSpec.swift
@@ -4,14 +4,13 @@
 // MIT Licence
 //
 
-import PathKit
 import Spectre
 import Stencil
 import XCTest
 
 final class TemplateLoaderTests: XCTestCase {
   func testFileSystemLoader() {
-    let path = Path(#file as String) + ".." + "fixtures"
+    let path = URL(fileURLWithPath: #file).deletingLastPathComponent().appendingPathComponent("fixtures")
     let loader = FileSystemLoader(paths: [path])
     let environment = Environment(loader: loader)
 


### PR DESCRIPTION
In order to support Windows, PathKit must be removed.  Porting PathKit turned out to be more difficult than anticipated and it was easier to remove that in favour of Foundation.