### PR TITLE
Fix documentation so it compiles

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ feel right at home with Stencil.
       ]
     ]
 
-    let environment = Environment(loader: FileSystemLoader(paths: ["templates/"])
+    let environment = Environment(loader: FileSystemLoader(paths: ["templates/"]))
     let rendered = try environment.renderTemplate(name: "articles.html", context: context)
 
     print(rendered)


### PR DESCRIPTION
Initial docs don't compile cause it's missing a parentheses. 